### PR TITLE
Add options for force redirection when navigate with ui-router

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,8 +79,8 @@ function UnsavedChangedService($injector, $window, $rootScope, $location) {
     }
   }
 
-  function onStateChange(ev, nextState, params) {
-    if (hasUnsavedChanges()) {
+  function onStateChange(ev, nextState, params, fromState, fromParam, options) {
+    if (!(options && options.force) && hasUnsavedChanges()) {
       ev.preventDefault();
       confirmLocationChange(() => $state.go(nextState, params));
       return false;


### PR DESCRIPTION
Add an option with ui-router for force the navigation with ui-router without ask to unsaved-changes.

```
$state.go('newroute', {}, {force:true});
```
